### PR TITLE
Fix agent initialization and docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Evolution Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -30,3 +30,19 @@ python evolution_sim.py --agents 200 --device cuda
 ```
 
 Move the slider at the bottom of the window to accelerate or slow down the simulation.
+
+### Configuration
+
+Key constants controlling the simulation are defined near the top of `evolution_sim.py`:
+
+- `FOOD_PER_ROUND` – number of food dots spawned each round.
+- `MAX_AGE` – maximum lifetime (in rounds) of an agent.
+- `SURVIVAL_FOOD` – minimum food required per round to stay alive.
+- `REPRODUCTION_THRESHOLD` – energy an agent needs before it can reproduce.
+- `REPRODUCTION_COST` – energy cost paid by each parent on reproduction.
+
+Modifying these values allows you to tune the difficulty of survival. Each agent starts with `SURVIVAL_FOOD` energy so it can survive the first round. You can override the starting energy when using the `Simulation` class directly via the `initial_energy` argument.
+
+## License
+
+This project is licensed under the terms of the MIT License. See [LICENSE](LICENSE) for details.

--- a/evolution_sim.py
+++ b/evolution_sim.py
@@ -15,10 +15,10 @@ MOVE_SPEED = 2.0
 
 
 class Simulation:
-    def __init__(self, num_agents: int, device: str = "cpu"):
+    def __init__(self, num_agents: int, device: str = "cpu", initial_energy: int = SURVIVAL_FOOD):
         self.device = torch.device(device)
         self.positions = torch.rand(num_agents, 2, device=self.device) * torch.tensor([WIDTH, HEIGHT], device=self.device)
-        self.energy = torch.zeros(num_agents, device=self.device)
+        self.energy = torch.full((num_agents,), initial_energy, device=self.device)
         self.age = torch.zeros(num_agents, dtype=torch.int32, device=self.device)
         self.food = torch.empty(0, 2, device=self.device)
 


### PR DESCRIPTION
## Summary
- initialize each agent with enough starting energy so they live through the first round
- add MIT license
- document configuration constants and license reference in the README

## Testing
- `python -m py_compile evolution_sim.py`
- `pip install pygame` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687a0a3af30c83238cf7490f90e2d71d